### PR TITLE
Shadow: add color param

### DIFF
--- a/src/exported_files/shadows.pr
+++ b/src/exported_files/shadows.pr
@@ -16,7 +16,7 @@ extension View {
     {{ createDocumentationComment(token.description, "    ") }}
     {[/]}
     func shadow{[ inject "token_func_name" context this /]}() -> some View {
-        return self.shadow({[ inject "color" context token.value.color /]}, radius: {{ token.value.radius.measure }}, x: {{ token.value.x.measure }}, y: {{ token.value.y.measure }}) 
+        return self.shadow(color: {[ inject "color" context token.value.color /]}, radius: {{ token.value.radius.measure }}, x: {{ token.value.x.measure }}, y: {{ token.value.y.measure }}) 
     }
     {[/]}
     {[/]}


### PR DESCRIPTION
👋 

I've been using the exporter already, but have had to fix this manually in our repo.

As per the docs we should be passing the color param: https://developer.apple.com/documentation/swiftui/view/shadow(color:radius:x:y:)

